### PR TITLE
Bugfix in list.js. Slice without arguments.

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -100,16 +100,16 @@ class List extends Wrapper
     }
 
     /**
-     * Get ramge of elements with BEGIN-END arguments
+     * Get range of elements with BEGIN-END arguments
      * Command: LRANGE
      *
      * Supports just the same interface as Array does.
      *
-     * @param  {Number}  begin Start point index
-     * @param  {Number}  end   End point index
+     * @param  {Number}  [begin=0]  Start point index
+     * @param  {Number}  [end=null] End point index
      * @return {Promise}
      */
-    slice(begin, end = null) {
+    slice(begin = 0, end = null) {
 
         switch (true) {
             case (end === null && begin < 0):


### PR DESCRIPTION
**User story:**
I tried to use **slice** without arguments and got following error:

```
node_redis: Deprecated: The LRANGE command contains a "undefined" argument.
This is converted to a "undefined" string now and will return an error from v.3.0 on.
Please handle this in your code to make sure everything works as you intended it to.
(node:71880) UnhandledPromiseRejectionWarning: ReplyError: ERR value is not an integer or out of range
    at parseError (/Users/romanfrolov/Desktop/tau/main-server/node_modules/redis-parser/lib/parser.js:193:12)
    at parseType (/Users/romanfrolov/Desktop/tau/main-server/node_modules/redis-parser/lib/parser.js:303:14)
(node:71880) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:71880) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
---

This PR fixes the issue by setting default value for `begin` argument to 0.